### PR TITLE
Update README with install warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ This repository provides a basic setup for a browser-based life simulator built 
 
 ## Development
 
-1. Install dependencies for both `client` and `server`:
+1. **Install dependencies before running any other commands**:
    ```bash
    cd client && npm install
    cd ../server && npm install
    ```
+   If you encounter an error like `Cannot find package 'vite'`, it typically means the dependencies were not installed.
 2. Run the client in development mode:
    ```bash
    cd client


### PR DESCRIPTION
## Summary
- highlight that npm install must happen in both client and server before any other commands
- mention that `Cannot find package 'vite'` usually means dependencies weren't installed

## Testing
- `npm test` in client (fails: missing script)
- `npm test` in server (fails: no tests specified)

------
https://chatgpt.com/codex/tasks/task_e_6865f613b3c88320830b5d3a606ea513