### PR TITLE
Add dev API proxy config

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -7,6 +7,12 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Development proxy
+
+When running `npm run dev`, requests starting with `/api` are proxied to
+`http://localhost:3000`. This allows the React app to communicate with the
+Express backend without additional CORS configuration.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: { proxy: { '/api': 'http://localhost:3000' } },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/api` to the Express server
- mention API proxy in the client README

## Testing
- `npm install` in `client`
- `npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6865fa2bffac83209fcd79fa663fc0de