### PR TITLE
Implement basic map view and AI event endpoint

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,19 @@
 import './App.css'
 import HomeScreen from './components/HomeScreen'
+import MapView from './components/MapView'
+import GamblingGame from './components/GamblingGame'
+import { PlayerStatsProvider } from './hooks/usePlayerStats'
 
 function App() {
   return (
-    <div className="app-container">
-      <h1>ADHD Life</h1>
-      <HomeScreen />
-    </div>
+    <PlayerStatsProvider>
+      <div className="app-container">
+        <h1>ADHD Life</h1>
+        <HomeScreen />
+        <MapView />
+        <GamblingGame />
+      </div>
+    </PlayerStatsProvider>
   )
 }
 

--- a/client/src/components/GamblingGame.tsx
+++ b/client/src/components/GamblingGame.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+const GamblingGame = () => {
+  const [result, setResult] = useState<string | null>(null)
+
+  const play = () => {
+    const win = Math.random() > 0.5
+    setResult(win ? 'Wygrana!' : 'Przegrana :(')
+  }
+
+  return (
+    <div>
+      <h3>Prosta mini-gra hazardowa</h3>
+      <button onClick={play}>Zagraj</button>
+      {result && <p>{result}</p>}
+    </div>
+  )
+}
+
+export default GamblingGame

--- a/client/src/components/MapView.css
+++ b/client/src/components/MapView.css
@@ -1,0 +1,32 @@
+.map-view {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1rem;
+}
+
+.location {
+  padding: 0.5rem 1rem;
+  background-color: #e3e3e3;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+}

--- a/client/src/components/MapView.tsx
+++ b/client/src/components/MapView.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import './MapView.css'
+
+interface Location {
+  id: string
+  name: string
+}
+
+const locations: Location[] = [
+  { id: 'home', name: 'Dom' },
+  { id: 'gym', name: 'Siłownia' },
+  { id: 'pub', name: 'Pub' },
+]
+
+const MapView = () => {
+  const [selected, setSelected] = useState<Location | null>(null)
+
+  return (
+    <div className="map-view">
+      {locations.map((loc) => (
+        <button key={loc.id} className="location" onClick={() => setSelected(loc)}>
+          {loc.name}
+        </button>
+      ))}
+
+      {selected && (
+        <div className="modal">
+          <div className="modal-content">
+            <h2>{selected.name}</h2>
+            <button onClick={() => setSelected(null)}>Zamknij</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MapView

--- a/client/src/hooks/usePlayerStats.tsx
+++ b/client/src/hooks/usePlayerStats.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { PlayerStats } from '@shared/typings'
+
+const defaultStats: PlayerStats = {
+  boredom: 50,
+  intellectual: 50,
+  luxury: 50,
+  hunger: 50,
+  fatigue: 50,
+  sleep: 50,
+  social: 50,
+  love: 50,
+  sexuality: 50,
+  stress: 50,
+  addiction: 0,
+  hygiene: 50,
+  health: 50,
+  jobSatisfaction: 50,
+  selfDiscipline: 50,
+  openMindedness: 50,
+}
+
+interface StatsContext {
+  stats: PlayerStats
+  setStats: (stats: PlayerStats) => void
+}
+
+const PlayerStatsContext = createContext<StatsContext | undefined>(undefined)
+
+export const PlayerStatsProvider = ({ children }: { children: ReactNode }) => {
+  const [stats, setStats] = useState<PlayerStats>(defaultStats)
+
+  return (
+    <PlayerStatsContext.Provider value={{ stats, setStats }}>
+      {children}
+    </PlayerStatsContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const usePlayerStats = () => {
+  const context = useContext(PlayerStatsContext)
+  if (!context) throw new Error('usePlayerStats must be used within provider')
+  return context
+}

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -11,6 +11,10 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
+    "baseUrl": "./",
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    },
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
@@ -23,5 +27,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "../shared"]
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,12 +3,37 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
 // Serve static files from the client build
 app.use(express.static(path.join(__dirname, '../client/dist')));
 
 // API endpoint placeholder
 app.get('/api/hello', (req, res) => {
   res.json({ message: 'Hello from the backend!' });
+});
+
+// Simple AI event endpoint placeholder
+app.post('/api/ai/event', (req, res) => {
+  const events = [
+    {
+      text: 'Spotykasz tajemniczego przechodnia oferującego szybki zarobek.',
+      options: [
+        { id: 'accept', description: 'Przyjmij ofertę' },
+        { id: 'decline', description: 'Odmów i odejdź' },
+      ],
+    },
+    {
+      text: 'Znajdujesz portfel na chodniku.',
+      options: [
+        { id: 'keep', description: 'Zachowaj pieniądze' },
+        { id: 'return', description: 'Odnies portfel właścicielowi' },
+      ],
+    },
+  ];
+
+  const event = events[Math.floor(Math.random() * events.length)];
+  res.json(event);
 });
 
 // Fallback to index.html for SPA routes

--- a/shared/typings.ts
+++ b/shared/typings.ts
@@ -1,0 +1,28 @@
+export interface PlayerStats {
+  boredom: number;
+  intellectual: number;
+  luxury: number;
+  hunger: number;
+  fatigue: number;
+  sleep: number;
+  social: number;
+  love: number;
+  sexuality: number;
+  stress: number;
+  addiction: number;
+  hygiene: number;
+  health: number;
+  jobSatisfaction: number;
+  selfDiscipline: number;
+  openMindedness: number;
+}
+
+export interface AIEventOption {
+  id: string;
+  description: string;
+}
+
+export interface AIEvent {
+  text: string;
+  options: AIEventOption[];
+}


### PR DESCRIPTION
## Summary
- add PlayerStats typings and context hook
- implement MapView and simple gambling mini-game
- create AI event endpoint in Express server
- adjust TypeScript config for shared types

## Testing
- `npm run build` in `client`
- `npm run lint` in `client`
- `node index.js` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68660ec631e08320b0cff9531fd03a86